### PR TITLE
feat: add FreeRolesAnomalyDetector.ts (not system-tested yet)

### DIFF
--- a/src/events/guildMemberAdd.ts
+++ b/src/events/guildMemberAdd.ts
@@ -1,9 +1,11 @@
 import { GMDIExtension, Member } from "oceanic.js";
 import { gmdiGuildID } from "../handler/Config";
 import altPrevention from "../registry/altPrevention";
+import FreeRolesAnomalyDetector from "../handler/FreeRolesAnomalyDetector";
 
 export default async (client: GMDIExtension, member: Member) => {
   if (member.guild.id !== gmdiGuildID || member.bot) return;
 
+  FreeRolesAnomalyDetector.startDetect(member);
   return await altPrevention(client, member.guild, member);
 };

--- a/src/events/guildMemberRemove.ts
+++ b/src/events/guildMemberRemove.ts
@@ -1,12 +1,18 @@
 import { GMDIExtension, Guild, Member, User } from "oceanic.js";
 import { gmdiGuildID, firstGeneralTextChannelID } from "../handler/Config";
 import { EmbedBuilder as RichEmbed } from "@oceanicjs/builders";
+import FreeRolesAnomalyDetector from "../handler/FreeRolesAnomalyDetector";
 
 export default async (client: GMDIExtension, member: User | Member, guild: Guild) => {
   if (guild.id !== gmdiGuildID || member.bot) return;
 
   // skip if member still on verification pending
   if (member instanceof Member && member.pending) return;
+
+  // Anomaly detector
+  if (member instanceof Member) {
+    FreeRolesAnomalyDetector.stopDetect(member);
+  }
 
   // Embed
   const embed = new RichEmbed()

--- a/src/events/guildMemberUpdate.ts
+++ b/src/events/guildMemberUpdate.ts
@@ -3,6 +3,7 @@ import { Member, GMDIExtension, JSONMember } from "oceanic.js";
 import membershipScreenings from "../registry/membershipScreenings";
 import boostNotification from "../registry/boostNotification";
 import usernameModeration from "../registry/usernameModeration";
+import FreeRolesAnomalyDetector from "../handler/FreeRolesAnomalyDetector";
 
 export default async (client: GMDIExtension, member: Member, oldMember: JSONMember | null) => {
   // passed Membership Screenings
@@ -13,4 +14,7 @@ export default async (client: GMDIExtension, member: Member, oldMember: JSONMemb
 
   // guild nickname moderation
   usernameModeration(client, member, oldMember);
+
+  // anomaly detector
+  FreeRolesAnomalyDetector.memberUpdated(member);
 };

--- a/src/handler/Config.ts
+++ b/src/handler/Config.ts
@@ -34,3 +34,8 @@ export const cooldownMessageCooling = [
 ];
 
 export const evalPrefix = ".";
+
+export const freeRolesAnomalyDetectorConfig = {
+  maxAnomalyMs: 2 * 60 * 1000,
+  freeRoleIds: ["1234"] // TODO: Fill with the correct roles.
+};

--- a/src/handler/FreeRolesAnomalyDetector.ts
+++ b/src/handler/FreeRolesAnomalyDetector.ts
@@ -1,0 +1,210 @@
+import { Member } from "oceanic.js";
+import { freeRolesAnomalyDetectorConfig as detectorConfig } from "./Config";
+
+type FreeRolesAnomalyDetectorInfo = {
+    status: boolean;
+    detail: {
+        maxAnomalyMs: number;
+        startTimestamp: number;
+        stopTimestamp: number;
+        durationMs: number;
+    }
+};
+
+class FreeRolesAnomalyDetector {
+    private freeRoleIds: string[];
+    private maxAnomalyMs: number;
+    private detectCallback: (info: FreeRolesAnomalyDetectorInfo) => void;
+    private startTimeMap: {
+        [memberId: string]: number
+    } = {};
+    
+    constructor(
+        config: {
+            freeRoleIds: string[],
+            maxAnomalyMs: number,
+        },
+        detectCallback: (info: FreeRolesAnomalyDetectorInfo) => void
+    ) {
+        const { freeRoleIds, maxAnomalyMs } = config;
+        this.freeRoleIds = freeRoleIds;
+        this.maxAnomalyMs = maxAnomalyMs;
+        this.detectCallback = detectCallback;
+    };
+
+    startDetect(member: Member) {
+        /**
+         * Call this method to set a start reference for detecting anomaly.
+         */
+        this.startTimeMap[member.id] = Date.now();
+    }
+
+    stopDetect(member: Member) {
+        /**
+         * Call this method if no need to check that member again.
+         */
+        if (!(member.id in this.startTimeMap)) return; // Ignore.
+        delete this.startTimeMap[member.id];
+    }
+
+    memberUpdated(member: Member) {
+        /**
+         * Call this method every time a member is updated.
+         */
+        if (!(member.id in this.startTimeMap)) return; // Ignore.
+
+        for (const roleId of this.freeRoleIds) {
+            if (!member.roles.includes(roleId)) {
+                return; // At least one free role hasn't been taken yet; ignore.
+            }
+        }
+        // All free roles have been taken.
+
+        const startTimestamp = this.startTimeMap[member.id];
+        delete this.startTimeMap[member.id];
+
+        const info = this.makeInfo(startTimestamp);
+        this.detectCallback(info);
+    }
+
+    private makeInfo(startTimestamp: number) {
+        const stopTimestamp = Date.now();
+        const durationMs = stopTimestamp - startTimestamp;
+        const maxAnomalyMs = this.maxAnomalyMs;
+
+        const status = (durationMs < maxAnomalyMs);
+        const detail = { startTimestamp, stopTimestamp, durationMs, maxAnomalyMs };
+        return { status, detail };
+    }
+};
+
+// Testing: executed asynchronously to prevent blocking 
+Promise.all([
+    // Test 1: Anomaly path
+    new Promise((resolve, reject) => {
+        const config = {
+            freeRoleIds: ["Role1", "Role2"],
+            maxAnomalyMs: 5 * 1000
+        };
+
+        const dummyMember = { id: "Member1", roles: [] as string[] } as Member;
+        const frad = new FreeRolesAnomalyDetector(config, info => {
+            if (dummyMember.roles.length < config.freeRoleIds.length) {
+                reject("FreeRolesAnomalyDetector - Test 1 failed - unsufficient member roles");
+            } else if (info.status != true) {
+                reject("FreeRolesAnomalyDetector - Test 1 failed - status should be true");
+            } else if (info.detail.maxAnomalyMs != config.maxAnomalyMs) {
+                reject("FreeRolesAnomalyDetector - Test 1 failed - detail.durationMs should be same as given");
+            } else if (info.detail.durationMs >= info.detail.maxAnomalyMs) {
+                reject("FreeRolesAnomalyDetector - Test 1 failed - detail.durationMs should be smaller than detail.maxAnomalyMs");
+            } else {
+                resolve(true);
+            }
+            clearTimeout(waitCallTimeout);
+        });
+
+        frad.startDetect(dummyMember);
+        setTimeout(() => {
+            dummyMember.roles.push("Role1");
+            frad.memberUpdated(dummyMember);
+            setTimeout(() => {
+                dummyMember.roles.push("Role2");
+                frad.memberUpdated(dummyMember);
+            }, 100);
+        }, 100);
+
+        const waitCallTimeout = setTimeout(() => {
+            reject("FreeRolesAnomalyDetector - Test 1 failed - callback should be called after all roles have been taken");
+        }, 1000);
+    }),
+
+    // Test 2: Not-anomaly path
+    new Promise((resolve, reject) => {
+        const config = {
+            freeRoleIds: ["Role1", "Role2"],
+            maxAnomalyMs: 100
+        };
+
+        const frad = new FreeRolesAnomalyDetector(config, info => {
+            if (info.status != false) {
+                reject("FreeRolesAnomalyDetector - Test 2 failed - status should be false");
+            } else if (info.detail.maxAnomalyMs != config.maxAnomalyMs) {
+                reject("FreeRolesAnomalyDetector - Test 2 failed - detail.durationMs should be same as given");
+            } else if (info.detail.durationMs < info.detail.maxAnomalyMs) {
+                reject("FreeRolesAnomalyDetector - Test 2 failed - detail.durationMs should not be smaller than detail.maxAnomalyMs");
+            } else {
+                resolve(true);
+            }
+            clearTimeout(waitCallTimeout);
+        });
+
+        const roles: string[] = [];
+        const dummyMember = { id: "Member1", roles } as Member;
+        frad.startDetect(dummyMember);
+        setTimeout(() => {
+            roles.push("Role1");
+            frad.memberUpdated(dummyMember);
+
+            setTimeout(() => {
+                roles.push("Role2");
+                frad.memberUpdated(dummyMember);
+            }, 100);
+        }, 100);
+
+        const waitCallTimeout = setTimeout(() => {
+            reject("FreeRolesAnomalyDetector - Test 2 failed - callback should be called after all roles have been taken");
+        }, 1000);
+    }),
+
+    // Test 3: Old member path
+    new Promise((resolve, reject) => {
+        const config = {
+            freeRoleIds: ["Role1", "Role2"],
+            maxAnomalyMs: 100
+        };
+
+        const frad = new FreeRolesAnomalyDetector(config, () => {
+            reject("FreeRolesAnomalyDetector - Test 3 failed - callback should not be called");
+            clearTimeout(waitCallTimeout);
+        });
+
+        const dummyMember = { id: "Member1", roles: ["Role1", "Role2"] } as Member;
+        frad.memberUpdated(dummyMember); // No startDetect
+        const waitCallTimeout = setTimeout(() => {
+            resolve(true);
+        }, 500);
+    }),
+
+    // Test 4: Stop detect functionality
+    new Promise((resolve, reject) => {
+        const config = {
+            freeRoleIds: ["Role1", "Role2"],
+            maxAnomalyMs: 100
+        };
+
+        const frad = new FreeRolesAnomalyDetector(config, () => {
+            reject("FreeRolesAnomalyDetector - Test 4 failed - callback should not be called");
+            clearTimeout(waitCallTimeout);
+        });
+
+        const dummyMember = { id: "Member1", roles: ["Role1", "Role2"] } as Member;
+        frad.startDetect(dummyMember);
+        frad.stopDetect(dummyMember); // Here we don't check the roles.
+        frad.memberUpdated(dummyMember);
+        const waitCallTimeout = setTimeout(() => {
+            resolve(true);
+        }, 500);
+    })
+])
+.then(() => {
+    console.log("FreeRolesAnomalyDetector - All tests success");
+})
+.catch(reason => {
+    console.error(reason);
+});
+
+const { freeRoleIds, maxAnomalyMs } = detectorConfig;
+export default new FreeRolesAnomalyDetector({ freeRoleIds, maxAnomalyMs }, x => {
+    // TODO: Call bot prevention manager
+    console.log(x); // Logging is important.
+});


### PR DESCRIPTION
This pull request contains a `FreeRolesAnomalyDetector` class for the second-rule bot prevention that was talked in 10 March 2024. Here is the summary for the changes:
- The component can be imported as object for usage.
- The component has been integrated in `src/events`.
- The component can be configured in `src/handler/Config.ts`. Currently, the free role list is arbitrary.
- The component has been unit tested, but not system tested.
- The component callback can be customized in `src/handler/FreeRolesAnomalyDetector.ts`. Currently, it just a logging process.

Future actions:
- Test the entire system with this component.
- Configure the free roles.
- Integrate the callback to bot prevention manager that handle other rules.